### PR TITLE
Minor improvements to CompositeDelegateAdapter

### DIFF
--- a/sample-app/cda/src/main/java/com/ingjuanocampo/cdapter/CompositeDelegateAdapter.kt
+++ b/sample-app/cda/src/main/java/com/ingjuanocampo/cdapter/CompositeDelegateAdapter.kt
@@ -5,10 +5,14 @@ import androidx.collection.SparseArrayCompat
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 
-open class CompositeDelegateAdapter(private val delegateCapacity: Int) : RecyclerView.Adapter<DelegateViewHolder>() {
+internal typealias Delegate = (ViewGroup) -> DelegateViewHolder
 
-    private var delegateAdapters: SparseArrayCompat<(ViewGroup) -> DelegateViewHolder> = SparseArrayCompat(delegateCapacity)
-    var items: ArrayList<RecyclerViewType> = ArrayList()
+open class CompositeDelegateAdapter(delegateCapacity: Int) :
+    RecyclerView.Adapter<DelegateViewHolder>() {
+
+    private var delegateAdapters: SparseArrayCompat<Delegate> =
+        SparseArrayCompat(delegateCapacity)
+    private val items: MutableList<RecyclerViewType> = mutableListOf()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DelegateViewHolder {
         return delegateAdapters[viewType]?.invoke(parent)!!
@@ -23,45 +27,49 @@ open class CompositeDelegateAdapter(private val delegateCapacity: Int) : Recycle
 
     override fun getItemCount() = items.size
 
-    fun addNewItems(itemsToInsert: List<RecyclerViewType>) {
-        val originalItems = items.toMutableList()
+    fun addNewItems(itemsToInsert: List<RecyclerViewType>) = with(items) {
+        val originalItems = toMutableList()
         if (itemsToInsert.isNullOrEmpty().not()) {
-            items.addAll(itemsToInsert)
+            addAll(itemsToInsert)
         }
-        dispatchUpdates(originalItems, items)
+        dispatchUpdates(originalItems, this)
     }
 
-    private fun dispatchUpdates(originalItems: MutableList<RecyclerViewType>, items: java.util.ArrayList<RecyclerViewType>) {
-        val diffResult = DiffUtil.calculateDiff(DelegateDiffCallback(originalItems, items))
-        diffResult.dispatchUpdatesTo(this)
+    private fun dispatchUpdates(
+        originalItems: MutableList<RecyclerViewType>,
+        items: MutableList<RecyclerViewType>
+    ) {
+        DiffUtil.calculateDiff(DelegateDiffCallback(originalItems, items)).apply {
+            dispatchUpdatesTo(this@CompositeDelegateAdapter)
+        }
     }
 
     fun addNewItem(itemToAdd: RecyclerViewType) = addNewItems(arrayListOf(itemToAdd))
 
-    fun deleteItems(itemsToRemove: List<RecyclerViewType>) {
-        val originalItems = items.toMutableList()
+    fun deleteItems(itemsToRemove: List<RecyclerViewType>) = with(items) {
+        val originalItems = toMutableList()
         if (itemsToRemove.isNullOrEmpty().not()) {
-            items.removeAll(itemsToRemove)
+            removeAll(itemsToRemove)
         }
-        dispatchUpdates(originalItems, items)
+        dispatchUpdates(originalItems, this)
     }
 
     fun deleteItem(itemToRemove: RecyclerViewType) = deleteItems(arrayListOf(itemToRemove))
 
     fun updateItem(item: RecyclerViewType) = updateItems(arrayListOf(item))
 
-    fun updateItems(itemsToUpdate: List<RecyclerViewType>) {
-        val originalItems = items.toMutableList()
+    fun updateItems(itemsToUpdate: List<RecyclerViewType>) = with(items) {
+        val originalItems = toMutableList()
+        clear()
         if (itemsToUpdate.isNullOrEmpty().not()) {
-            items.clear()
-            items.addAll(itemsToUpdate)
-        } else items.clear()
-        dispatchUpdates(originalItems, items)
+            addAll(itemsToUpdate)
+        }
+        dispatchUpdates(originalItems, this)
     }
 
     fun clearAll() = updateItems(emptyList())
 
-    fun appendDelegate(viewType: Int, delegate: (ViewGroup) -> DelegateViewHolder) {
+    fun appendDelegate(viewType: Int, delegate: Delegate) {
         delegateAdapters.put(viewType, delegate)
     }
 }


### PR DESCRIPTION
Change list:
* created an `internal typealias` for `(ViewGroup) -> DelegateViewHolder`.
* removed not needed variable for `delegateCapacity`
* function `updateItems()` improved: `clear()` is going to be called always so moving it out of `If Else`
* function `dispatchUpdates()` now uses `apply()` (kotlin style) instead java variable style
* using `with()` across all file for a more kotlin style.