### PR TITLE
ViewHolder memory leak fix

### DIFF
--- a/sample-app/app/src/main/java/com/ingjuanocampo/cdapter/sample/delegate/ColorDA.kt
+++ b/sample-app/app/src/main/java/com/ingjuanocampo/cdapter/sample/delegate/ColorDA.kt
@@ -8,7 +8,7 @@ import com.ingjuanocampo.cdapter.DelegateViewHolder
 import com.ingjuanocampo.cdapter.RecyclerViewType
 import com.ingjuanocampo.cdapter.sample.R
 
-data class ColorItemViewHolder( val parent: ViewGroup):
+class ColorItemViewHolder(parent: ViewGroup):
     DelegateViewHolder(LayoutInflater.from(parent.context).inflate(R.layout.delegate_color, parent, false)) {
 
     private val tvDelegate = itemView.findViewById<TextView>(R.id.tvDelegate)


### PR DESCRIPTION
Having a class variable like val parent: ViewGroup would cause a memory leak and crash in a recyclerView like:
`illegalArgumentException: Scrapped or attached views may not be recycled. isScrap:false isAttached:true androidx.recyclerview.widget.RecyclerView`

Above exception will happens when you have animations like MotionLayout or just simply changing recycler's size dynamically (hidding other sibling UI element with an user action).